### PR TITLE
Update to criterion 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ description = "Iterate over Protobuf messages while decoding on the fly"
 documentation = "https://docs.rs/protobuf_iter/"
 repository = "https://github.com/astro/rust-protobuf-iter/"
 
-[dev-dependencies]
-criterion = "0.2"
-
 [[bench]]
 name = "varint_parse"
 harness = false
+
+[dev-dependencies]
+criterion = { version = "0.8", default-features = false }


### PR DESCRIPTION
When using criterion 0.2, Rust 2024 emits a warning that the upcoming language edition won’t be able to compile this dependency anymore.