### PR TITLE
Fix lint warnings

### DIFF
--- a/src/message_iter.rs
+++ b/src/message_iter.rs
@@ -10,12 +10,12 @@ pub struct MessageIter<'a> {
 
 impl<'a> MessageIter<'a> {
     pub fn new(data: &'a [u8]) -> Self {
-        MessageIter { data: data }
+        MessageIter { data }
     }
 
     pub fn tag<T: From<ParseValue<'a>>>(self, tag: u32) -> ByTag<'a, T> {
         ByTag {
-            tag: tag,
+            tag,
             inner: self,
             items: PhantomData,
         }
@@ -26,7 +26,7 @@ impl<'a> MessageIter<'a> {
 impl<'a> From<ParseValue<'a>> for MessageIter<'a> {
     fn from(value: ParseValue<'a>) -> MessageIter<'a> {
         match value {
-            ParseValue::LengthDelimited(data) => MessageIter::new(data.as_ref()),
+            ParseValue::LengthDelimited(data) => MessageIter::new(data),
             _ => panic!("Expected buffer to parse"),
         }
     }

--- a/src/packed.rs
+++ b/src/packed.rs
@@ -54,7 +54,7 @@ pub struct PackedIter<'a, P, T> {
 impl<'a, P, T> PackedIter<'a, P, T> {
     pub fn new(data: &'a [u8]) -> Self {
         PackedIter {
-            data: data,
+            data,
             packed: PhantomData,
             item: PhantomData,
         }
@@ -73,7 +73,7 @@ impl<'a, P: Packed<'a>, T: From<<P as Packed<'a>>::Item>> Iterator for PackedIte
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.data.len() < 1 {
+        if self.data.is_empty() {
             return None;
         }
 


### PR DESCRIPTION
After this change, `cargo clippy` does not give any warnings.