### PR TITLE
CI: Publish tagged releases to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Publish release to crates.io
+
+on:
+  push:
+    tags: ['v*']  # triggered by pushing a tag such as 'v0.1.2'
+
+permissions: {}
+
+jobs:
+  test:
+    name: Run tests for release candidate
+    permissions: {}
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - name: Build
+      run: cargo build --release
+    - name: Run tests
+      run: cargo test --release
+
+  # https://crates.io/docs/trusted-publishing
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: [test]
+    permissions:
+      id-token: write  # for OIDC token exchange
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - name: Authenticate with crates.io
+      uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec  # v1.0.3
+      id: auth
+    - name: Publish release
+      run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
@astro If you’re ok with this, can you enable [Trusted Publishing](https://crates.io/docs/trusted-publishing) in your crates.io config? I can’t really test this beforehand, but we’ll see if it works.

1. Go to your crate's Settings → Trusted Publishing
2. Click the "Add" button and select GitHub as the platform
3. Fill in the platform-specific fields:
    * Repository owner: `astro`
    * Repository name: `rust-protobuf-iter`
    * Workflow filename: `release.yml`
4. Save