### PR TITLE
Add unit test for converting Field to ParseValue

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -11,3 +11,20 @@ impl<'a> From<Field<'a>> for ParseValue<'a> {
         m.value
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse::parse_field;
+    use crate::varint::Varint;
+
+    #[test]
+    fn test_parse_value_from_field() {
+        let data = [0x08, 0x96, 0x01];
+        let (field, _rest) = parse_field(&data).unwrap();
+        assert_eq!(
+            ParseValue::from(field),
+            ParseValue::Varint(Varint { value: 150 })
+        );
+    }
+}


### PR DESCRIPTION
Before this change, the code in `field.rs` was not covered by tests.